### PR TITLE
Fixed PAK creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Chromium Language PAK
 Fork that allows conversion of language PAK files to Gettext PO and from PO to PAK
 
-## From PAK to Gettext PO
-Call `unpack.py` with _directory_ as a po file. Example: `python unpack.py en-US.pak en-US.po`
+## From PAK to Gettext PO or POT
+Call `unpack.py` with _directory_ as a po or pot file. Examples:
+
+`python unpack.py en-US.pak en-US.po` creates a PO file
+`python unpack.py en-US.pak en-US.pot` creates a POT file
 
 ## From Gettext PO to PAK
 Simply call `pack.py` with _directory_ as a po file. Example: `python pack.py en-US.po`

--- a/pack.py
+++ b/pack.py
@@ -7,7 +7,7 @@ import paktools
 
 def main():
   if len(sys.argv) <= 1:
-    print("Usage: {0} <directory> [file]".format(sys.argv[0])
+    print("Usage: {0} <directory> [file]".format(sys.argv[0]))
     return
   
   directory = sys.argv[1]

--- a/paktools.py
+++ b/paktools.py
@@ -192,9 +192,10 @@ def UnpackFileIntoDirectory(pakFile, directory):
         contents = contents.replace("\"", "\\\"")
         contents = contents.replace("\n", "\\n\"\n\"")
         file.write("msgctxt \"" + str(resource_id) + "\"\nmsgid \"" + contents + "\"\n")
+        file.write("msgstr \"")
         if not name.group(2):
-          file.write("msgstr \"" + contents + "\"\n")
-        file.write("\n")
+          file.write(contents)
+        file.write("\"\n\n")
   else:
     if os.path.exists(directory):
       shutil.rmtree(directory)

--- a/paktools.py
+++ b/paktools.py
@@ -101,8 +101,8 @@ def WriteDataPackToString(resources, encoding):
 
   # Write data.
   for id in ids:
-    ret.append(resources[id])
-  return ''.join(ret)
+    ret.append(resources[id].encode())
+  return b''.join(ret)
 
 def WriteDataPack(resources, output_file, encoding):
   """Write a map of id=>data into output_file as a data pack."""
@@ -144,8 +144,7 @@ def PackDirectoryIntoFile(directory, pakFile):
         POstring = entry.msgstr
       #print(id)
       #print(POstring) 
-        
-    data[int(id)] = POstring
+      data[int(id)] = POstring
 
   WriteDataPack(data, pakFile, UTF8)
 

--- a/paktools.py
+++ b/paktools.py
@@ -178,7 +178,7 @@ def UnpackFileIntoDirectory(pakFile, directory):
   data = ReadDataPack(pakFile)
   #print data.encoding
 
-  name = re.search("^([a-zA-Z-]+).*\.po$", directory)
+  name = re.search("^([a-zA-Z-]+).*\.po(t)?$", directory)
   if name:
     with open(directory, "w") as file:
       file.write("msgid \"\"\nmsgstr \"\"\n\"Project-Id-Version: Vivaldi Chromium Strings\\n\"\n\"Language-Team: Vivaldi Translation Team\\n\"\n\"Last-Translator: Vivaldi Translation Team\\n\"\n\"Report-Msgid-Bugs-To: https://github.com/An-dz/ChromiumPoPak/issues\\n\"\n\"POT-Creation-Date: " +
@@ -191,7 +191,10 @@ def UnpackFileIntoDirectory(pakFile, directory):
       for (resource_id, contents) in data.resources.iteritems():
         contents = contents.replace("\"", "\\\"")
         contents = contents.replace("\n", "\\n\"\n\"")
-        file.write("msgctxt \"" + str(resource_id) + "\"\nmsgid \"" + contents + "\"\nmsgstr \"" + contents + "\"\n\n")
+        file.write("msgctxt \"" + str(resource_id) + "\"\nmsgid \"" + contents + "\"\n")
+        if not name.group(2):
+          file.write("msgstr \"" + contents + "\"\n")
+        file.write("\n")
   else:
     if os.path.exists(directory):
       shutil.rmtree(directory)


### PR DESCRIPTION
The problem is that Python 3 is stronger than 2. If you check the documentation you'll see that python 2 does not care about DataType, but on Python 3 it will fail:

http://devdocs.io/python~2.7/library/stdtypes#str.join  
http://devdocs.io/python~3.5/library/stdtypes#str.join

So when calling `''.join(ret)` it expect everything in `ret` to be strings because `''` is a string.

The `for` at the end of `WriteDataPackToString` appends `string` but the rest before it appends `bytes`, so you need to convert one of them to make all of them one type. The choice is obvious when it calls `file.write()` which expects `bytes`.