### PR TITLE
Calculate correct length

### DIFF
--- a/paktools.py
+++ b/paktools.py
@@ -95,7 +95,7 @@ def WriteDataPackToString(resources, encoding):
   data_offset = HEADER_LENGTH + index_length
   for id in ids:
     ret.append(struct.pack("<HI", id, data_offset))
-    data_offset += len(resources[id])
+    data_offset += len(resources[id].encode())
 
   ret.append(struct.pack("<HI", 0, data_offset))
 


### PR DESCRIPTION
The Python3 code was returning the number of chars in the string, but we need the UTF-8 encoded size as special characters can be represented by multiple bytes.